### PR TITLE
account planFeatures should be an array

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliengo/mfe-utils",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "exports": {
     "./mod": "./mod.ts",
     "./types": "./types/index.ts",

--- a/types/Account.ts
+++ b/types/Account.ts
@@ -104,6 +104,6 @@ export interface AccountWithFeatures extends Account {
     value: boolean;
     /** brief description of what the user does with the feature */
     entitlementName: string;
-  };
+  }[];
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Change the `planFeatures` field in the `AccountWithFeatures` interface from a single object to an array of objects.