### PR TITLE
Support for patch account and local support

### DIFF
--- a/clients/cliengo.client.ts
+++ b/clients/cliengo.client.ts
@@ -23,7 +23,16 @@ export const getCliengoClient = (args: {
       console.warn('CliengoClient: Environment is not set, serving stage URL by default.');
     }
 
-    baseUrl = getUrls(env as string).API_URL;
+    if (env === 'dev') {
+      baseUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL;
+      
+      if (!baseUrl) {
+        console.warn('CliengoClient: API_URL not found in environment variables for dev environment, falling back to getUrls');
+        baseUrl = getUrls(env as string).API_URL;
+      }
+    } else {
+      baseUrl = getUrls(env as string).API_URL;
+    }
 
      if (!baseUrl) {
       throw new CliengoClientError('Base URL is required');

--- a/clients/cliengo.client.ts
+++ b/clients/cliengo.client.ts
@@ -27,7 +27,11 @@ export const getCliengoClient = (args: {
       baseUrl = process.env.API_URL || process.env.NEXT_PUBLIC_API_URL;
       
       if (!baseUrl) {
-        console.warn('CliengoClient: API_URL not found in environment variables for dev environment, falling back to getUrls');
+        console.warn(
+          `CliengoClient: API_URL not found in environment variables for dev environment, falling back to getUrls. ` +
+          `process.env.API_URL: ${process.env.API_URL ?? 'undefined'}, ` +
+          `process.env.NEXT_PUBLIC_API_URL: ${process.env.NEXT_PUBLIC_API_URL ?? 'undefined'}`
+        );
         baseUrl = getUrls(env as string).API_URL;
       }
     } else {

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliengo/mfe-utils",
-  "version": "0.5.22",
+  "version": "0.5.23",
   "exports": {
     "./mod": "./mod.ts",
     "./types": "./types/index.ts",

--- a/services/cliengo.service.ts
+++ b/services/cliengo.service.ts
@@ -30,6 +30,15 @@ export class CliengoService {
   }
 
   /**
+   * @mutation
+   */
+  public async patchAccount(payload: Record<string, unknown>) {
+    const { data } = await this.http.patch('/account', payload);
+
+    return data;
+  }
+
+  /**
    * @query
    */
   public async getPlan() {


### PR DESCRIPTION
## Summary by Sourcery

Add support for local dev environment base URL overrides and introduce a patchAccount endpoint in the Cliengo service

New Features:
- Add patchAccount method in CliengoService to support PATCH /account

Enhancements:
- Load API_URL or NEXT_PUBLIC_API_URL from environment variables when env is dev, with fallback to default URLs and warning logs if missing