### PR TITLE
feat(EXP-18): add chargebeeAccount to Account type

### DIFF
--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@cliengo/mfe-utils",
-  "version": "0.5.30",
+  "version": "0.5.31",
   "exports": {
     "./mod": "./mod.ts",
     "./types": "./types/index.ts",

--- a/types/Account.ts
+++ b/types/Account.ts
@@ -31,6 +31,7 @@ export interface Account {
   subscriptionMethod: string;
   forceChargebee: boolean;
   forceMercadoPago: boolean;
+  chargebeeAccount?: string;
   quickstartSteps: QuickstartSteps;
   shouldFireScriptPixel: boolean;
   affiliateProgramCode: string;


### PR DESCRIPTION
## Problem

The `chargebeeAccount` field was missing from the `Account` TypeScript interface in `mfe-utils`. This caused `accountData?.chargebeeAccount` to always resolve to `undefined`, meaning the `?chargebeeAccount=` query param was never sent to cb-proxy from any rapidash component.

## Fix

Added `chargebeeAccount?: string` to the `Account` interface, next to the other Chargebee-related fields:

```ts
forceChargebee: boolean;
forceMercadoPago: boolean;
chargebeeAccount?: string;  // added
```

Optional to match the backend null-safe getter: `null` in DB returns `"cliengo"` via `getChargebeeAccount()`. `AccountWithFeatures` inherits the field automatically.

## Version bump

`0.5.30` → `0.5.31`

After merging, run `yarn install:mfe-utils` in rapidash to pick up the new version.

addresses EXP-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Expose an optional chargebeeAccount field on the Account interface for downstream consumers.